### PR TITLE
fix(amazonq): improve line numbering in Explain and Fix commands

### DIFF
--- a/packages/amazonq/src/lsp/chat/commands.ts
+++ b/packages/amazonq/src/lsp/chat/commands.ts
@@ -41,7 +41,11 @@ export function registerCommands(provider: AmazonQChatViewProvider) {
                     })
                 }
 
-                const visibleMessageInChat = `_Explain **${issue.title}** issue in **${path.basename(filePath)}** at \`(${issue.startLine}, ${issue.endLine})\`_`
+                const lineRange =
+                    issue.startLine === issue.endLine - 1
+                        ? `[${issue.startLine + 1}]`
+                        : `[${issue.startLine + 1}, ${issue.endLine}]`
+                const visibleMessageInChat = `_Explain **${issue.title}** issue in **${path.basename(filePath)}** at \`${lineRange}\`_`
 
                 // The message that gets sent to the backend
                 const contextMessage = `Provide a small description of the issue. Do not attempt to fix the issue, only explain it. Code issue - ${JSON.stringify(issue)}`
@@ -73,7 +77,11 @@ export function registerCommands(provider: AmazonQChatViewProvider) {
                     })
                 }
 
-                const visibleMessageInChat = `_Fix **${issue.title}** issue in **${path.basename(filePath)}** at \`(${issue.startLine}, ${issue.endLine})\`_`
+                const lineRange =
+                    issue.startLine === issue.endLine - 1
+                        ? `[${issue.startLine + 1}]`
+                        : `[${issue.startLine + 1}, ${issue.endLine}]`
+                const visibleMessageInChat = `_Fix **${issue.title}** issue in **${path.basename(filePath)}** at \`${lineRange}\`_`
 
                 // The message that gets sent to the backend
                 const contextMessage = `Generate a fix for the following code issue. Do not explain the issue, just generate and explain the fix. The user should have the option to accept or reject the fix before any code is changed. Code issue - ${JSON.stringify(issue)}`


### PR DESCRIPTION
## Problem
When using the Explain and Fix commands, the start line number was 1 too low.

## Solution
Incremented the start line number. replaced `()` with `[]` to indicate inclusive boundaries. When the issue is only on one line, only write the number once.

![image](https://github.com/user-attachments/assets/da465cb2-939b-40b5-8ad3-01b14d587d45)

![image](https://github.com/user-attachments/assets/28d3cbd5-61b4-43b1-86f1-b428c80b7af5)


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
